### PR TITLE
define local variables

### DIFF
--- a/tutorial/1-wordseg/script/grade.pl
+++ b/tutorial/1-wordseg/script/grade.pl
@@ -8,6 +8,7 @@ use List::Util qw(max min);
 sub levenshtein {
     my ($s, $t) = @_;
     my (@sc, $m, @tc, $n, %d, @str, $i, $j, $id, $cost, $type, $aid, $bid, $cid, $c);
+    my (@d, %str);
     @sc = split(/ /, $s);
     $m = @sc;
     @tc = split(/ /, $t);


### PR DESCRIPTION
tutorial/1-wordseg/script/grade.pl is not work on perl 5.20.2.

```
 % perl grade.pl 
Global symbol "@d" requires explicit package name at grade.pl line 16.
Global symbol "%str" requires explicit package name at grade.pl line 17.
Global symbol "%str" requires explicit package name at grade.pl line 18.
Global symbol "%str" requires explicit package name at grade.pl line 38.
Global symbol "%str" requires explicit package name at grade.pl line 38.
Global symbol "%str" requires explicit package name at grade.pl line 43.
Global symbol "%str" requires explicit package name at grade.pl line 43.
Global symbol "%str" requires explicit package name at grade.pl line 47.
Global symbol "%str" requires explicit package name at grade.pl line 47.
Global symbol "%str" requires explicit package name at grade.pl line 51.
Global symbol "%str" requires explicit package name at grade.pl line 57.
BEGIN not safe after errors--compilation aborted at grade.pl line 65.
```

The patch adds definition of these variables.
